### PR TITLE
remove eyedropper

### DIFF
--- a/src/components/ColorSelectors.jsx
+++ b/src/components/ColorSelectors.jsx
@@ -101,14 +101,14 @@ const ColorSelectors = ({
   return (
     <>
       {/* Eyedropper only available on Desktop */}
-      {window.innerWidth > 768 && (
+      {/* {window.innerWidth > 768 && (
         <IconButton
           ButtonIcon={BsEyedropper}
           buttonText={'EyeDropper'}
           clickEvent={activateEyeDropper}
           disabled={activeSelectedItem ? false : true}
         />
-      )}
+      )} */}
 
       {!colorPaletteVisibility && (
         <ColorButton


### PR DESCRIPTION
remove eyedropper 😭
Behavior seems to be unreliable. Working fine on deployed site and local version in chrome/ firefox browsers on Windows 10. Does not return accurate pixel color on deployed site or local version on MacOS chrome or firefox browsers 🤔 odd 